### PR TITLE
Fix sparse constraints with constraint of different types

### DIFF
--- a/src/Bridges/Constraint/sos_polynomial.jl
+++ b/src/Bridges/Constraint/sos_polynomial.jl
@@ -86,14 +86,14 @@ _list_variables(Q::Vector{Vector{MOI.VariableIndex}}) = Iterators.flatten(Q)
 function MOI.get(bridge::SOSPolynomialBridge, ::MOI.ListOfVariableIndices)
     _list_variables(bridge.Q)
 end
-_num_constraints(cQ::Vector{C}, ::Type{C}) where C = length(cQ)
+_num_constraints(cQ::Vector, ::Type{C}) where C = count(ci -> ci isa C, cQ)
 _num_constraints(cQ::C, ::Type{C}) where C = 1
 _num_constraints(cQ, ::Type) = 0
 function MOI.get(bridge::SOSPolynomialBridge{T, F, DT, UMCT, UMST},
                  ::MOI.NumberOfConstraints{MOI.VectorOfVariables, S}) where {T, F, DT, UMCT, UMST, S<:UMST}
     return _num_constraints(bridge.cQ, MOI.ConstraintIndex{MOI.VectorOfVariables, S})
 end
-_list_constraints(cQ::Vector{C}, ::Type{C}) where C = cQ
+_list_constraints(cQ::Vector, ::Type{C}) where C = filter(ci -> ci isa C, cQ)
 _list_constraints(cQ::C, ::Type{C}) where C = [cQ]
 _list_constraints(cQ, C::Type) = C[]
 function MOI.get(bridge::SOSPolynomialBridge{T, F, DT, UMCT, UMST},

--- a/src/Bridges/Constraint/utilities.jl
+++ b/src/Bridges/Constraint/utilities.jl
@@ -1,13 +1,9 @@
 function union_constraint_types(MCT)
-    return Union{MOI.ConstraintIndex{MOI.VectorOfVariables, typeof(SOS.matrix_cone(MCT, 0))},
-                 MOI.ConstraintIndex{MOI.VectorOfVariables, typeof(SOS.matrix_cone(MCT, 1))},
-                 MOI.ConstraintIndex{MOI.VectorOfVariables, typeof(SOS.matrix_cone(MCT, 2))},
-                 MOI.ConstraintIndex{MOI.VectorOfVariables, typeof(SOS.matrix_cone(MCT, 3))},
-                 Vector{MOI.ConstraintIndex{MOI.VectorOfVariables, typeof(SOS.matrix_cone(MCT, 0))}},
-                 Vector{MOI.ConstraintIndex{MOI.VectorOfVariables, typeof(SOS.matrix_cone(MCT, 1))}},
-                 Vector{MOI.ConstraintIndex{MOI.VectorOfVariables, typeof(SOS.matrix_cone(MCT, 2))}},
-                 Vector{MOI.ConstraintIndex{MOI.VectorOfVariables, typeof(SOS.matrix_cone(MCT, 3))}}}
-    # `Vector{<:MOI.ConstraintIndex}` is for sparse SOS
+    UMCT = SOS.union_constraint_indices_types(MCT)
+    return Union{UMCT, Vector{UMCT}}
+    # `Vector{UMCT}` is for sparse SOS
+    # As basis can have different sizes, we need `Vector{Union{...}}` instead of
+    # `Union{Vector, ...}`.
 end
 function union_set_types(MCT)
     return Union{typeof(SOS.matrix_cone(MCT, 0)),


### PR DESCRIPTION
They could have different types for instance if some vector of monomials have small size so we can use LP or SOCP and other have large size.
This did not occur that often with VariableSparsity which is why did bug was not detect but it is now quite common with MonomialSparsity and SignSymmetry.