### PR TITLE
Fix Gram Matrix for other types than Float64

### DIFF
--- a/bench/gram_to_poly.jl
+++ b/bench/gram_to_poly.jl
@@ -5,7 +5,7 @@ function gram_to_poly(n)
     model = MOIU.Model{Float64}()
     @polyvar x
     monos = monomials(x, 0:n)
-    q, Q, con_Q = SumOfSquares.add_gram_matrix(model, MOI.PositiveSemidefiniteConeTriangle, monos)
+    q, Q, con_Q = SumOfSquares.add_gram_matrix(model, MOI.PositiveSemidefiniteConeTriangle, monos, Float64)
     @time polynomial(q)
     return
 end

--- a/src/Bridges/Constraint/sos_polynomial_in_semialgebraic_set.jl
+++ b/src/Bridges/Constraint/sos_polynomial_in_semialgebraic_set.jl
@@ -1,7 +1,7 @@
 function lagrangian_multiplier(model::MOI.ModelLike, certificate, index, preprocessed, T::Type)
     basis = Certificate.get(certificate, Certificate.MultiplierBasis(), index, preprocessed)
     MCT = SOS.matrix_cone_type(typeof(certificate))
-    return SOS.add_gram_matrix(model, MCT, basis)..., basis
+    return SOS.add_gram_matrix(model, MCT, basis, T)..., basis
 end
 
 struct SOSPolynomialInSemialgebraicSetBridge{
@@ -152,9 +152,9 @@ function MOI.get(model::MOI.ModelLike,
     return MOI.get(model, attr, bridge.constraint)
 end
 function MOI.get(model::MOI.ModelLike, attr::SOS.LagrangianMultipliers,
-                 bridge::SOSPolynomialInSemialgebraicSetBridge)
+                 bridge::SOSPolynomialInSemialgebraicSetBridge{T}) where T
     @assert eachindex(bridge.lagrangian_variables) == eachindex(bridge.lagrangian_bases)
     map(i -> _gram(Q -> MOI.get(model, MOI.VariablePrimal(attr.N), Q),
-                   bridge.lagrangian_variables[i], bridge.lagrangian_bases[i]),
+                   bridge.lagrangian_variables[i], bridge.lagrangian_bases[i], T),
         eachindex(bridge.lagrangian_variables))
 end

--- a/src/SumOfSquares.jl
+++ b/src/SumOfSquares.jl
@@ -15,8 +15,6 @@ Reexport.@reexport using MultivariateBases
 # @set assumes that `SemialgebraicSets` is defined
 Reexport.@reexport using SemialgebraicSets
 Reexport.@reexport using MultivariateMoments
-_promote_sum(T::Type) = MA.promote_operation(+, T, T)
-_promote_add_mul(T::Type) = MA.promote_operation(MA.add_mul, T, T, T)
 
 include("gram_matrix.jl")
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,8 +1,13 @@
+# The second type is ignored. For `T = VariableRef`, it should be `Float64` anyway
+# since JuMP only supports `Float64`.
+_promote_sum(T::Type, ::Type=Float64) = MA.promote_operation(+, T, T)
 # `+` is not defined between `MOI.SingleVariable`.
-_promote_sum(::Type{MOI.SingleVariable}) = MOI.ScalarAffineFunction{Float64}
+_promote_sum(::Type{MOI.SingleVariable}, T::Type=Float64) = MOI.ScalarAffineFunction{T}
+
+_promote_add_mul(T::Type) = MA.promote_operation(MA.add_mul, T, T, T)
 _promote_add_mul(::Type{MOI.SingleVariable}) = MOI.ScalarQuadraticFunction{Float64}
-function MP.polynomial(p::GramMatrix{MOI.SingleVariable})
-    Q = convert(Vector{MOI.ScalarAffineFunction{Float64}}, p.Q.Q)
+function MP.polynomial(p::GramMatrix{MOI.SingleVariable, B, U}) where {B, U}
+    Q = convert(Vector{U}, p.Q.Q)
     return MP.polynomial(GramMatrix(SymMatrix(Q, p.Q.n), p.basis))
 end
 #function MP.polynomial(p::GramMatrix{F}) where {F <: MOI.AbstractFunction}

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -65,6 +65,7 @@ function JuMP.add_variable(model::JuMP.AbstractModel,
     Q = moi_add_variable(backend(model), set, v.binary, v.integer)
     return build_gram_matrix(
         JuMP.VariableRef[JuMP.VariableRef(model, vi) for vi in Q],
-        v.p.polynomial_basis
+        v.p.polynomial_basis,
+        Float64
     )
 end

--- a/test/gram_matrix.jl
+++ b/test/gram_matrix.jl
@@ -152,4 +152,17 @@
             @test !isapprox(SOSDecompositionWithDomain(ps, [ps1, ps1], K), sosdec)
         end
     end
+
+    @testset "build_gram_matrix" begin
+        v = MOI.VariableIndex.(1:3)
+        @polyvar x y
+        basis = MonomialBasis(monomials([x, y], 1))
+        @testset "$T" for T in [Float64, Complex{Float64}, Int, BigFloat]
+            g = SumOfSquares.build_gram_matrix(v, basis, T)
+            @test g isa GramMatrix{MOI.SingleVariable, typeof(basis), MOI.ScalarAffineFunction{T}}
+            p = polynomial(g)
+            @test p isa AbstractPolynomial{MOI.ScalarAffineFunction{T}}
+            @test typeof(p) == polynomialtype(g)
+        end
+    end
 end


### PR DESCRIPTION
Before this PR, the GramMatrix was using `Float64` independently of the type of the bridge.