### PR TITLE
Further reduce if degree of irrep is > 1

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 CSDP = "0a46da34-8e4b-519e-b418-48813639ff34"
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Cyclotomics = "da8f5974-afbb-4dc8-91d8-516d5257c83b"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 CSDP = "0a46da34-8e4b-519e-b418-48813639ff34"
 Cyclotomics = "da8f5974-afbb-4dc8-91d8-516d5257c83b"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -93,10 +93,10 @@ be used with another JuMP extension that also has a special model constructor.
 A third alternative is the following:
 ```jldoctest constraint-pq
 julia> PolyJuMP.setdefault!(model, PolyJuMP.NonNegPoly, SOSCone)
-NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}
+SOSCone (alias for NonnegPolyInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle})
 
 julia> PolyJuMP.setdefault!(model, PolyJuMP.PosDefPolyMatrix, SOSMatrixCone)
-PSDMatrixInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle}
+SOSMatrixCone (alias for PSDMatrixInnerCone{MathOptInterface.PositiveSemidefiniteConeTriangle})
 ```
 This approach adds the flexibility to choose the default cone for
 
@@ -113,7 +113,7 @@ For instance, to use the diagonally-dominant-sum-of-squares cone (see
 [Definition 2, AM17]) for the first type of contraints, do
 ```jldoctest constraint-pq
 julia> PolyJuMP.setdefault!(model, PolyJuMP.NonNegPoly, DSOSCone)
-NonnegPolyInnerCone{SumOfSquares.DiagonallyDominantConeTriangle}
+DSOSCone (alias for NonnegPolyInnerCone{SumOfSquares.DiagonallyDominantConeTriangle})
 ```
 
 ## Changing the polynomial basis

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -51,21 +51,21 @@ Just like with classical JuMP's decision variables, containers of polynomial
 variables can be created as follows:
 ```jldoctest variables
 julia> @variable(model, [1:3, 1:4], Poly(X))       # Creates a Matrix
-3×4 Array{Polynomial{true,VariableRef},2}:
+3×4 Matrix{Polynomial{true,VariableRef}}:
  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)  …  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)
  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)     (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)
  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)     (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)
 
-julia> @variable(model, [[:a, :b], -2:2], Poly(X)) # Creates a JuMPArray
+julia> @variable(model, [[:a, :b], -2:2], Poly(X)) # Creates a DenseAxisArray
 2-dimensional DenseAxisArray{DynamicPolynomials.Polynomial{true,VariableRef},2,...} with index sets:
     Dimension 1, [:a, :b]
     Dimension 2, -2:2
-And data, a 2×5 Array{DynamicPolynomials.Polynomial{true,VariableRef},2}:
+And data, a 2×5 Matrix{DynamicPolynomials.Polynomial{true,VariableRef}}:
  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)  …  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)
  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)     (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)
 
-julia> @variable(model, [i=1:3, j=i:3], Poly(X))   # Creates a Dict
-JuMP.Containers.SparseAxisArray{Polynomial{true,VariableRef},2,Tuple{Int64,Int64}} with 6 entries:
+julia> @variable(model, [i=1:3, j=i:3], Poly(X))   # Creates a SparseAxisArray
+JuMP.Containers.SparseAxisArray{Polynomial{true, VariableRef}, 2, Tuple{Int64, Int64}} with 6 entries:
   [1, 2]  =  (noname)*x^2 + (noname)*x*y + (noname)*y^2 + (noname)*x + (noname)*y + (noname)
   [2, 3]  =  (noname)*x^2 + (noname)*x*y + (noname)*y^2 + (noname)*x + (noname)*y + (noname)
   [3, 3]  =  (noname)*x^2 + (noname)*x*y + (noname)*y^2 + (noname)*x + (noname)*y + (noname)
@@ -102,7 +102,7 @@ For instance, the following code creates a ``3 \times 4`` matrix of
 sum-of-squares polynomial variables:
 ```jldoctest variables
 julia> @variable(model, [1:2], SOSPoly(X))
-2-element Array{GramMatrix{VariableRef,MonomialBasis{Monomial{true},MonomialVector{true}},GenericAffExpr{Float64,VariableRef},SymMatrix{VariableRef}},1}:
+2-element Vector{GramMatrix{VariableRef,MonomialBasis{Monomial{true},MonomialVector{true}},GenericAffExpr{Float64,VariableRef},SymMatrix{VariableRef}}}:
  GramMatrix{VariableRef,MonomialBasis{Monomial{true},MonomialVector{true}},GenericAffExpr{Float64,VariableRef},SymMatrix{VariableRef}}(VariableRef[noname noname … noname noname; noname noname … noname noname; … ; noname noname … noname noname; noname noname … noname noname], MonomialBasis{Monomial{true},MonomialVector{true}}(DynamicPolynomials.Monomial{true}[x², xy, y², x, y, 1]))
  GramMatrix{VariableRef,MonomialBasis{Monomial{true},MonomialVector{true}},GenericAffExpr{Float64,VariableRef},SymMatrix{VariableRef}}(VariableRef[noname noname … noname noname; noname noname … noname noname; … ; noname noname … noname noname; noname noname … noname noname], MonomialBasis{Monomial{true},MonomialVector{true}}(DynamicPolynomials.Monomial{true}[x², xy, y², x, y, 1]))
 ```
@@ -135,7 +135,7 @@ For instance, creating an univariate cubic polynomial variable `p` using the
 Chebyshev basis can be done as follows:
 ```jldoctest variables
 julia> cheby_basis = FixedPolynomialBasis([1, x, 2x^2-1, 4x^3-3x])
-FixedPolynomialBasis{Polynomial{true,Int64},Array{Polynomial{true,Int64},1}}(DynamicPolynomials.Polynomial{true,Int64}[1, x, 2x² - 1, 4x³ - 3x])
+FixedPolynomialBasis{Polynomial{true, Int64}, Vector{Polynomial{true, Int64}}}(DynamicPolynomials.Polynomial{true, Int64}[1, x, 2x² - 1, 4x³ - 3x])
 
 julia> @variable(model, variable_type=Poly(cheby_basis))
 (4 noname)x³ + (2 noname)x² + (noname - 3 noname)x + (noname - noname)
@@ -150,7 +150,7 @@ julia> X = monomials([x, y], 2)
  y²
 
 julia> scaled_basis = ScaledMonomialBasis(X)
-ScaledMonomialBasis{Monomial{true},MonomialVector{true}}(DynamicPolynomials.Monomial{true}[x², xy, y²])
+ScaledMonomialBasis{Monomial{true}, MonomialVector{true}}(DynamicPolynomials.Monomial{true}[x², xy, y²])
 
 julia> @variable(model, variable_type=Poly(scaled_basis))
 (noname)x² + (1.4142135623730951 noname)xy + (noname)y²
@@ -158,7 +158,7 @@ julia> @variable(model, variable_type=Poly(scaled_basis))
 which is equivalent to
 ```jldoctest variables
 julia> scaled_basis = FixedPolynomialBasis([x^2, √2*x*y, y^2])
-FixedPolynomialBasis{Term{true,Float64},Array{Term{true,Float64},1}}(DynamicPolynomials.Term{true,Float64}[x², 1.4142135623730951xy, y²])
+FixedPolynomialBasis{Term{true, Float64}, Vector{Term{true, Float64}}}(DynamicPolynomials.Term{true, Float64}[x², 1.4142135623730951xy, y²])
 
 julia> @variable(model, variable_type=Poly(scaled_basis))
 (noname)x² + (1.4142135623730951 noname)xy + (noname)y²

--- a/docs/src/variables.md
+++ b/docs/src/variables.md
@@ -51,27 +51,27 @@ Just like with classical JuMP's decision variables, containers of polynomial
 variables can be created as follows:
 ```jldoctest variables
 julia> @variable(model, [1:3, 1:4], Poly(X))       # Creates a Matrix
-3×4 Matrix{Polynomial{true,VariableRef}}:
+3×4 Matrix{Polynomial{true, VariableRef}}:
  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)  …  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)
  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)     (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)
  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)     (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)
 
 julia> @variable(model, [[:a, :b], -2:2], Poly(X)) # Creates a DenseAxisArray
-2-dimensional DenseAxisArray{DynamicPolynomials.Polynomial{true,VariableRef},2,...} with index sets:
+2-dimensional DenseAxisArray{DynamicPolynomials.Polynomial{true, VariableRef},2,...} with index sets:
     Dimension 1, [:a, :b]
     Dimension 2, -2:2
-And data, a 2×5 Matrix{DynamicPolynomials.Polynomial{true,VariableRef}}:
+And data, a 2×5 Matrix{DynamicPolynomials.Polynomial{true, VariableRef}}:
  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)  …  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)
  (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)     (noname)x² + (noname)xy + (noname)y² + (noname)x + (noname)y + (noname)
 
 julia> @variable(model, [i=1:3, j=i:3], Poly(X))   # Creates a SparseAxisArray
 JuMP.Containers.SparseAxisArray{Polynomial{true, VariableRef}, 2, Tuple{Int64, Int64}} with 6 entries:
   [1, 2]  =  (noname)*x^2 + (noname)*x*y + (noname)*y^2 + (noname)*x + (noname)*y + (noname)
-  [2, 3]  =  (noname)*x^2 + (noname)*x*y + (noname)*y^2 + (noname)*x + (noname)*y + (noname)
-  [3, 3]  =  (noname)*x^2 + (noname)*x*y + (noname)*y^2 + (noname)*x + (noname)*y + (noname)
-  [2, 2]  =  (noname)*x^2 + (noname)*x*y + (noname)*y^2 + (noname)*x + (noname)*y + (noname)
   [1, 1]  =  (noname)*x^2 + (noname)*x*y + (noname)*y^2 + (noname)*x + (noname)*y + (noname)
+  [3, 3]  =  (noname)*x^2 + (noname)*x*y + (noname)*y^2 + (noname)*x + (noname)*y + (noname)
   [1, 3]  =  (noname)*x^2 + (noname)*x*y + (noname)*y^2 + (noname)*x + (noname)*y + (noname)
+  [2, 2]  =  (noname)*x^2 + (noname)*x*y + (noname)*y^2 + (noname)*x + (noname)*y + (noname)
+  [2, 3]  =  (noname)*x^2 + (noname)*x*y + (noname)*y^2 + (noname)*x + (noname)*y + (noname)
 ```
 
 For more flexibility, polynomials parametrized by decision variables can also
@@ -102,9 +102,9 @@ For instance, the following code creates a ``3 \times 4`` matrix of
 sum-of-squares polynomial variables:
 ```jldoctest variables
 julia> @variable(model, [1:2], SOSPoly(X))
-2-element Vector{GramMatrix{VariableRef,MonomialBasis{Monomial{true},MonomialVector{true}},GenericAffExpr{Float64,VariableRef},SymMatrix{VariableRef}}}:
- GramMatrix{VariableRef,MonomialBasis{Monomial{true},MonomialVector{true}},GenericAffExpr{Float64,VariableRef},SymMatrix{VariableRef}}(VariableRef[noname noname … noname noname; noname noname … noname noname; … ; noname noname … noname noname; noname noname … noname noname], MonomialBasis{Monomial{true},MonomialVector{true}}(DynamicPolynomials.Monomial{true}[x², xy, y², x, y, 1]))
- GramMatrix{VariableRef,MonomialBasis{Monomial{true},MonomialVector{true}},GenericAffExpr{Float64,VariableRef},SymMatrix{VariableRef}}(VariableRef[noname noname … noname noname; noname noname … noname noname; … ; noname noname … noname noname; noname noname … noname noname], MonomialBasis{Monomial{true},MonomialVector{true}}(DynamicPolynomials.Monomial{true}[x², xy, y², x, y, 1]))
+2-element Vector{GramMatrix{VariableRef, MonomialBasis{Monomial{true}, MonomialVector{true}}, AffExpr, SymMatrix{VariableRef}}}:
+ GramMatrix{VariableRef, MonomialBasis{Monomial{true}, MonomialVector{true}}, AffExpr, SymMatrix{VariableRef}}(VariableRef[noname noname … noname noname; noname noname … noname noname; … ; noname noname … noname noname; noname noname … noname noname], MonomialBasis{Monomial{true}, MonomialVector{true}}(DynamicPolynomials.Monomial{true}[x², xy, y², x, y, 1]))
+ GramMatrix{VariableRef, MonomialBasis{Monomial{true}, MonomialVector{true}}, AffExpr, SymMatrix{VariableRef}}(VariableRef[noname noname … noname noname; noname noname … noname noname; … ; noname noname … noname noname; noname noname … noname noname], MonomialBasis{Monomial{true}, MonomialVector{true}}(DynamicPolynomials.Monomial{true}[x², xy, y², x, y, 1]))
 ```
 There is however an *important* difference between the meaning of the
 vector of monomials `X` between `Poly` and `SOSPoly`. For `SOSPoly`, it

--- a/examples/Dihedral symmetry of the Robinson form.jl
+++ b/examples/Dihedral symmetry of the Robinson form.jl
@@ -145,24 +145,24 @@ function solve(G)
 
     g = gram_matrix(con_ref).sub_gram_matrices #src
     @test length(g) == 5                       #src
-    @test g[1].basis.polynomials == [x*y^2, x^3, x] #src
-    @test g[2].basis.polynomials == [x^2*y, y^3, y] #src
+    @test g[1].basis.polynomials == [x*y^2, x, x^3] #src
+    @test g[2].basis.polynomials == [x^2*y, y, y^3] #src
     for i in 1:2                        #src
         I = 3:-1:1                      #src
         Q = g[i].Q[I, I]                #src
         @test size(Q) == (3, 3)         #src
-        @test Q[1, 1] ≈ 25/64 rtol=1e-3 #src
+        @test Q[1, 1] ≈  1    rtol=1e-3 #src
         @test Q[1, 2] ≈ -5/8  rtol=1e-3 #src
-        @test Q[1, 3] ≈  5/8  rtol=1e-3 #src
-        @test Q[2, 2] ≈  1    rtol=1e-3 #src
-        @test Q[2, 3] ≈ -1    rtol=1e-3 #src
+        @test Q[1, 3] ≈ -1    rtol=1e-3 #src
+        @test Q[2, 2] ≈ 25/64 rtol=1e-3 #src
+        @test Q[2, 3] ≈  5/8  rtol=1e-3 #src
         @test Q[3, 3] ≈  1    rtol=1e-3 #src
     end #src
     @test g[3].basis.polynomials == [x^2 + y^2, 1.0] #src
     @test size(g[3].Q) == (2, 2)             #src
     @test g[3].Q[2, 2] ≈ 7921/4096 rtol=1e-3 #src
     @test g[3].Q[1, 2] ≈  -89/128 rtol=1e-3  #src
-    @test g[3].Q[1, 1] ≈ 1/4 rtol=1e-3 #src
+    @test g[3].Q[1, 1] ≈ 1/4 rtol=1e-2 #src
     @test g[4].basis.polynomials == [x * y] #src
     @test size(g[4].Q) == (1, 1)       #src
     @test g[4].Q[1, 1] ≈ 0   atol=1e-3 #src

--- a/examples/Even reduction.jl
+++ b/examples/Even reduction.jl
@@ -38,7 +38,8 @@ solver = CSDP.Optimizer
 model = Model(solver)
 @variable(model, t)
 @objective(model, Max, t)
-con_ref = @constraint(model, poly - t in SOSCone(), ideal_certificate = SymmetricIdeal(SOSCone(), G, action))
+certificate = SymmetricIdeal(Certificate.MaxDegree(SOSCone(), MonomialBasis, maxdegree(poly)), G, action)
+con_ref = @constraint(model, poly - t in SOSCone(), ideal_certificate = certificate)
 optimize!(model)
 @test value(t) ≈ -1 #src
 value(t)

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 CSDP = "0a46da34-8e4b-519e-b418-48813639ff34"
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Cyclotomics = "da8f5974-afbb-4dc8-91d8-516d5257c83b"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 CSDP = "0a46da34-8e4b-519e-b418-48813639ff34"
 Cyclotomics = "da8f5974-afbb-4dc8-91d8-516d5257c83b"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"

--- a/examples/Symmetry reduction.jl
+++ b/examples/Symmetry reduction.jl
@@ -2,7 +2,7 @@
 
 #md # [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/generated/Symmetry reduction.ipynb)
 #md # [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/Symmetry reduction.ipynb)
-# **Adapted from**: https://github.com/kalmarek/SymbolicWedderburn.jl/blob/tw/ex_sos/examples/ex_C4.jl
+# **Adapted from**: [SymbolicWedderburn example](https://github.com/kalmarek/SymbolicWedderburn.jl/blob/tw/ex_sos/examples/ex_C4.jl)
 
 import MutableArithmetics
 const MA = MutableArithmetics
@@ -36,6 +36,13 @@ function action(mono::AbstractMonomial, p::Perm)
     v = variables(mono)
     MP.substitute(MP.Eval(), mono, v => [v[i^p] for i in eachindex(v)])
 end
+function action(term::MP.AbstractTerm, el::Perm)
+    return MP.coefficient(term) * action(MP.monomial(term), el)
+end
+function action(poly::MP.AbstractPolynomial, el::Perm)
+    return MP.polynomial([action(term, el) for term in MP.terms(poly)])
+end
+
 G = PermGroup([perm"(1,2,3,4)"])
 
 # We can use this certificate as follows:
@@ -45,12 +52,30 @@ solver = CSDP.Optimizer
 model = Model(solver)
 @variable(model, t)
 @objective(model, Max, t)
-con_ref = @constraint(model, poly - t in SOSCone(), ideal_certificate = SymmetricIdeal(SOSCone(), G, action))
+certificate = SymmetricIdeal(Certificate.MaxDegree(SOSCone(), MonomialBasis, maxdegree(poly)), G, action)
+con_ref = @constraint(model, poly - t in SOSCone(), ideal_certificate = certificate)
 optimize!(model)
 @test value(t) ≈ -1 #src
 value(t)
 
 # We indeed find `-1`, let's verify that symmetry was exploited:
 
-@test length(gram_matrix(con_ref).sub_gram_matrices) == 3 #src
-gram_matrix(con_ref)
+g = gram_matrix(con_ref).sub_gram_matrices #src
+@test length(g) == 4                       #src
+@test g[1].basis.polynomials == [sum(x), 1.0] #src
+@test size(g[1].Q) == (2, 2)                  #src
+@test g[1].Q[1, 1] ≈ 1/4 atol=1e-6            #src
+@test g[1].Q[1, 2] ≈ 1/2 atol=1e-6            #src
+@test g[1].Q[2, 2] ≈ 1.0 atol=1e-6            #src
+@test g[2].basis.polynomials == [x[1] - x[3]] #src
+@test size(g[2].Q) == (1, 1)                  #src
+@test g[2].Q[1, 1] ≈ 1/2 atol=1e-6            #src
+@test g[3].basis.polynomials == [x[2] - x[4]] #src
+@test size(g[3].Q) == (1, 1)                  #src
+@test g[3].Q[1, 1] ≈ 1/2 atol=1e-6            #src
+@test g[4].basis.polynomials == [x[1] - x[2] + x[3] - x[4]] #src
+@test size(g[4].Q) == (1, 1)                  #src
+@test g[4].Q[1, 1] ≈ 1/4 atol=1e-6            #src
+for g in gram_matrix(con_ref).sub_gram_matrices
+    println(g.basis.polynomials)
+end

--- a/examples/block_diag.jl
+++ b/examples/block_diag.jl
@@ -12,7 +12,7 @@ function row_echelon_linsolve(A::Matrix{T}, b::Vector{T}) where {T}
         end
         error("Not in row_echelon_form, cannot find for `$i`th entry.")
     end
-    @assert x'A == b'
+    @assert transpose(A) * x == b
     return x
 end
 
@@ -45,11 +45,15 @@ function ordered_block_diag(As, d)
         U[:, I] = U[:, I[σ_ok]]
         offset += d
     end
+    ordered_block_check(U, As, d)
+    return U
+end
+
+function ordered_block_check(U, As, d)
     iU = inv(U)
     @assert all(As) do A
         is_ordered_blockdim(U * A * iU, d)
     end
-    return U
 end
 
 function block_diag(As, d)
@@ -79,7 +83,7 @@ function block_diag(As, d)
                     Cs = [B[v, v] for B in Bs]
                     V = block_diag(Cs, d)
                     V === nothing && break
-                    V *= T[:, v]'
+                    V *= transpose(T[:, v])
                 end
                 U[:, offset .+ eachindex(v)] = V
                 offset += length(v)

--- a/examples/block_diag.jl
+++ b/examples/block_diag.jl
@@ -19,8 +19,9 @@ end
 function ordered_block_diag(As, d)
     U = block_diag(As, d)
     U === nothing && return nothing
-    iU = inv(U)
-    Bs = [U * A * inv(U) for A in As]
+    iU = U'
+    @assert iU ≈ inv(U)
+    Bs = [iU * A * U for A in As]
     @assert all(Bs) do B
         isblockdim(B, d)
     end
@@ -50,9 +51,10 @@ function ordered_block_diag(As, d)
 end
 
 function ordered_block_check(U, As, d)
-    iU = inv(U)
+    iU = U'
+    @assert iU ≈ inv(U)
     @assert all(As) do A
-        is_ordered_blockdim(U * A * iU, d)
+        is_ordered_blockdim(iU * A * U, d)
     end
 end
 
@@ -60,7 +62,8 @@ function block_diag(As, d)
     for A in As
         #T = eigen(A).vectors
         T = schur(A).vectors
-        iT = inv(T)
+        iT = T'
+        @assert iT ≈ inv(T)
         n = LinearAlgebra.checksquare(A)
         union_find = IntDisjointSets(n)
         Bs = [iT * A * T for A in As]

--- a/examples/block_diag.jl
+++ b/examples/block_diag.jl
@@ -1,0 +1,119 @@
+using LinearAlgebra
+using Combinatorics, DataStructures
+
+function row_echelon_linsolve(A::Matrix{T}, b::Vector{T}) where {T}
+    j = 0
+    x = map(1:size(A, 1)) do i
+        while j < size(A, 2)
+            j += 1
+            if isone(A[i, j]) && all(k -> k == i || iszero(A[k, j]), 1:size(A, 1))
+                return b[j]
+            end
+        end
+        error("Not in row_echelon_form, cannot find for `$i`th entry.")
+    end
+    @assert x'A == b'
+    return x
+end
+
+function ordered_block_diag(As, d)
+    U = block_diag(As, d)
+    U === nothing && return nothing
+    iU = inv(U)
+    Bs = [U * A * inv(U) for A in As]
+    @assert all(Bs) do B
+        isblockdim(B, d)
+    end
+    refs = [B[1:d, 1:d] for B in Bs]
+    offset = d
+    for offset in d:d:(size(U, 1) - d)
+        I = offset .+ (1:d)
+        Cs = [B[I, I] for B in Bs]
+        σ_ok = nothing
+        for σ in permutations(1:d)
+            if all(zip(refs, Cs)) do refC
+                ref, C = refC
+                isapprox(ref[σ, σ], C, rtol=1e-8)
+            end
+                σ_ok = σ
+                break
+            end
+        end
+        if σ_ok === nothing
+            error("No permutation can make $refs and $Cs match")
+        end
+        U[:, I] = U[:, I[σ_ok]]
+        offset += d
+    end
+    iU = inv(U)
+    @assert all(As) do A
+        is_ordered_blockdim(U * A * iU, d)
+    end
+    return U
+end
+
+function block_diag(As, d)
+    for A in As
+        #T = eigen(A).vectors
+        T = schur(A).vectors
+        iT = inv(T)
+        n = LinearAlgebra.checksquare(A)
+        union_find = IntDisjointSets(n)
+        Bs = [iT * A * T for A in As]
+        for B in Bs
+            merge_sparsity!(union_find, B)
+        end
+        blocks = Dict{Int,Vector{Int}}()
+        for i in 1:n
+            r = find_root!(union_find, i)
+            blocks[r] = push!(get(blocks, r, Int[]), i)
+        end
+        if length(blocks) > 1
+            U = similar(T)
+            offset = 0
+            for v in values(blocks)
+                @assert iszero(length(v) % d)
+                if length(v) == d
+                    V = T[:, v]
+                else
+                    Cs = [B[v, v] for B in Bs]
+                    V = block_diag(Cs, d)
+                    V === nothing && break
+                    V *= T[:, v]'
+                end
+                U[:, offset .+ eachindex(v)] = V
+                offset += length(v)
+            end
+            if offset == n
+                return U
+            end
+        end
+    end
+end
+
+function merge_sparsity!(union_find::IntDisjointSets, A, tol=1e-8)
+    for I in CartesianIndices(A)
+        i, j = I.I
+        if abs(A[I]) > tol
+            union!(union_find, i, j)
+        end
+    end
+end
+
+function is_ordered_blockdim(A, d, tol=1e-8)
+    B = A[1:d, 1:d]
+    return isblockdim(A, d, tol) &&
+        all(d:d:(size(A, 1) - d)) do offset
+            I = offset .+ (1:d)
+            isapprox(B, A[I, I], rtol=tol)
+        end
+end
+function isblockdim(A, d, tol=1e-8)
+    for I in CartesianIndices(A)
+        i, j = I.I
+        if abs(i - j) >= d && abs(A[I]) > tol
+            return false
+        end
+    end
+    return true
+end

--- a/examples/symmetry.jl
+++ b/examples/symmetry.jl
@@ -66,7 +66,6 @@ function Certificate.get(cert::SymmetricIdeal, attr::Certificate.GramBasis, poly
             else
                 U = Matrix(1.0I, N, N)
             end
-            ordered_block_check(U, S, d)
             map(1:d) do i
                 FixedPolynomialBasis((transpose(U[:, i:d:(i+d*(m-1))]) * F) * basis.monomials)
             end

--- a/examples/symmetry.jl
+++ b/examples/symmetry.jl
@@ -51,11 +51,11 @@ function Certificate.get(cert::SymmetricIdeal, attr::Certificate.GramBasis, poly
         if d > 1
             if m > 1
                 ps = R * basis.monomials
-                S = map(gens(G)) do g
-                    Si = Matrix{Float64}(undef, N, N)
+                S = map(gens(cert.group)) do g
+                    Si = Matrix{T}(undef, N, N)
                     for i in eachindex(ps)
                         p = ps[i]
-                        q = action(p, g)
+                        q = cert.action(p, g)
                         coefs = coefficients(q, basis.monomials)
                         col = row_echelon_linsolve(R, coefs)
                         Si[:, i] = col
@@ -64,10 +64,11 @@ function Certificate.get(cert::SymmetricIdeal, attr::Certificate.GramBasis, poly
                 end
                 U = ordered_block_diag(S, d)
             else
-                U = F
+                U = Matrix(1.0I, N, N)
             end
+            ordered_block_check(U, S, d)
             map(1:d) do i
-                FixedPolynomialBasis((U[:, i:d:(i+d*(m-1))]' * F) * basis.monomials)
+                FixedPolynomialBasis((transpose(U[:, i:d:(i+d*(m-1))]) * F) * basis.monomials)
             end
         else
             [FixedPolynomialBasis(F * basis.monomials)]

--- a/src/Bridges/Constraint/sos_polynomial.jl
+++ b/src/Bridges/Constraint/sos_polynomial.jl
@@ -187,13 +187,13 @@ function MOI.get(model::MOI.ModelLike,
                  attr::SOS.MomentMatrixAttribute,
                  bridge::SOSPolynomialBridge)
     if bridge.cQ isa Vector{<:MOI.ConstraintIndex}
-        return MultivariateMoments.SparseMomentMatrix([
-            SOS.build_moment_matrix(MOI.get(model, MOI.ConstraintDual(attr.N), cQ), monos)
-            for (cQ, monos) in zip(bridge.cQ, bridge.gram_basis)
-        ])
+        return SOS.build_moment_matrix(bridge.gram_basis) do i
+            MOI.get(model, MOI.ConstraintDual(attr.N), bridge.cQ[i])
+        end
     else
-        return SOS.build_moment_matrix(MOI.get(model, MOI.ConstraintDual(attr.N),
-                                               bridge.cQ),
-                                       bridge.gram_basis)
+        return SOS.build_moment_matrix(
+            MOI.get(model, MOI.ConstraintDual(attr.N), bridge.cQ),
+            bridge.gram_basis,
+        )
     end
 end


### PR DESCRIPTION
For each irrep, we either have a `multiplicity` of 0 in which case we have no block or we have a nonzero multiplicities in which case, before this PR we created and SDP of size `multiplicity * degree` and after this PR we add only one PSD variable to the solver of size multiplicity and put `degree` gram matrices (all equal) in the `SparseGramMatrix`.