### PR TITLE
Update for SymbolicWedderburn#38

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ MutableArithmetics = "0.2"
 PolyJuMP = "0.4.2"
 Reexport = "0.2, 1.0"
 SemialgebraicSets = "0.2"
-SymbolicWedderburn = "0.1"
+SymbolicWedderburn = "0.2"
 julia = "1"
 
 [extras]

--- a/docs/src/tutorials/Symmetry/dihedral_symmetry_of_the_robinson_form.jl
+++ b/docs/src/tutorials/Symmetry/dihedral_symmetry_of_the_robinson_form.jl
@@ -29,6 +29,7 @@ struct DihedralElement <: GroupsCore.GroupElement
     reflection::Bool
     id::Int
 end
+GroupsCore.parent(g::DihedralElement) = DihedralGroup(g.n)
 function Base.:(==)(g::DihedralElement, h::DihedralElement)
     return g.n == h.n && g.reflection == h.reflection && g.id == h.id
 end
@@ -71,8 +72,10 @@ struct DihedralGroup <: GroupsCore.Group
     n::Int
 end
 Base.one(G::DihedralGroup) = DihedralElement(G.n, false, 0)
+Base.isfinite(::DihedralGroup) = true
 PermutationGroups.gens(G::DihedralGroup) = [DihedralElement(G.n, false, 1), DihedralElement(G.n, true, 0)]
 PermutationGroups.order(::Type{T}, G::DihedralGroup) where {T} = convert(T, 2G.n)
+Base.eltype(::Type{DihedralGroup}) = DihedralElement
 function Base.iterate(G::DihedralGroup, prev::DihedralElement=DihedralElement(G.n, false, -1))
     if prev.id + 1 >= G.n
         if prev.reflection
@@ -101,7 +104,7 @@ using DynamicPolynomials
 @polyvar x y
 struct DihedralAction <: Symmetry.OnMonomials end
 import SymbolicWedderburn
-SymbolicWedderburn.coeff_type(::DihedralAction) = Float64
+SymbolicWedderburn._coeff_type(::DihedralAction) = Float64
 function SymbolicWedderburn.action(::DihedralAction, el::DihedralElement, mono::AbstractMonomial)
     if iseven(el.reflection + el.id)
         var_x, var_y = x, y

--- a/docs/src/tutorials/Symmetry/dihedral_symmetry_of_the_robinson_form.jl
+++ b/docs/src/tutorials/Symmetry/dihedral_symmetry_of_the_robinson_form.jl
@@ -105,7 +105,7 @@ using DynamicPolynomials
 @polyvar x y
 struct DihedralAction <: Symmetry.OnMonomials end
 import SymbolicWedderburn
-SymbolicWedderburn._coeff_type(::DihedralAction) = Float64
+SymbolicWedderburn.coeff_type(::DihedralAction) = Float64
 function SymbolicWedderburn.action(::DihedralAction, el::DihedralElement, mono::AbstractMonomial)
     if iseven(el.reflection + el.id)
         var_x, var_y = x, y

--- a/docs/src/tutorials/Symmetry/even_reduction.jl
+++ b/docs/src/tutorials/Symmetry/even_reduction.jl
@@ -18,7 +18,7 @@ using SumOfSquares
 struct OnSign <: Symmetry.OnMonomials end
 using PermutationGroups
 import SymbolicWedderburn
-SymbolicWedderburn.coeff_type(::OnSign) = Float64
+SymbolicWedderburn._coeff_type(::OnSign) = Float64
 function SymbolicWedderburn.action(::OnSign, p::Permutation, mono::AbstractMonomial)
     if isone(p) || iseven(DynamicPolynomials.degree(mono))
         return 1 * mono

--- a/docs/src/tutorials/Symmetry/even_reduction.jl
+++ b/docs/src/tutorials/Symmetry/even_reduction.jl
@@ -46,5 +46,5 @@ value(t)
 
 @test length(gram_matrix(con_ref).sub_gram_matrices) == 2 #src
 @test gram_matrix(con_ref).sub_gram_matrices[1].basis.polynomials == [x^2, 1] #src
-@test gram_matrix(con_ref).sub_gram_matrices[2].basis.polynomials == [x] #src
+@test gram_matrix(con_ref).sub_gram_matrices[2].basis.polynomials == [-x] #src
 gram_matrix(con_ref)

--- a/docs/src/tutorials/Symmetry/even_reduction.jl
+++ b/docs/src/tutorials/Symmetry/even_reduction.jl
@@ -7,7 +7,7 @@ using Test #src
 using DynamicPolynomials
 @polyvar x
 
-# We would like to find the minimum value of the polynomial
+# We would like to find the minimum value of the following polynomial:
 
 poly = x^4 - 2x^2
 

--- a/docs/src/tutorials/Symmetry/even_reduction.jl
+++ b/docs/src/tutorials/Symmetry/even_reduction.jl
@@ -18,7 +18,7 @@ using SumOfSquares
 struct OnSign <: Symmetry.OnMonomials end
 using PermutationGroups
 import SymbolicWedderburn
-SymbolicWedderburn._coeff_type(::OnSign) = Float64
+SymbolicWedderburn.coeff_type(::OnSign) = Float64
 function SymbolicWedderburn.action(::OnSign, p::Permutation, mono::AbstractMonomial)
     if isone(p) || iseven(DynamicPolynomials.degree(mono))
         return 1 * mono

--- a/docs/src/tutorials/Symmetry/permutation_symmetry.jl
+++ b/docs/src/tutorials/Symmetry/permutation_symmetry.jl
@@ -49,20 +49,21 @@ value(t)
 # We indeed find `-1`, let's verify that symmetry was exploited:
 
 g = gram_matrix(con_ref).sub_gram_matrices    #src
+display([g[i].basis.polynomials for i in eachindex(g)])
 @test length(g) == 4                          #src
 @test length(g[1].basis.polynomials) == 2     #src
-@test g[1].basis.polynomials[1] == 1.0        #src
-@test g[1].basis.polynomials[2] ≈ -0.5 * sum(x) #src
+@test g[1].basis.polynomials[1] ≈ 0.5 * sum(x) #src
+@test g[1].basis.polynomials[2] == 1.0        #src
 @test size(g[1].Q) == (2, 2)                  #src
-@test g[1].Q[1, 1] ≈  1.0 atol=1e-6           #src
-@test g[1].Q[1, 2] ≈ -1.0 atol=1e-6           #src
-@test g[1].Q[2, 2] ≈  1.0 atol=1e-6           #src
+@test g[1].Q[1, 1] ≈ 1.0 atol=1e-6            #src
+@test g[1].Q[1, 2] ≈ 1.0 atol=1e-6            #src
+@test g[1].Q[2, 2] ≈ 1.0 atol=1e-6            #src
 @test length(g[2].basis.polynomials) == 1     #src
-@test g[2].basis.polynomials[1] ≈ (x[2] - x[4]) / √2 #src
+@test g[2].basis.polynomials[1] ≈ (x[1] - x[3]) / √2 #src
 @test size(g[2].Q) == (1, 1)                  #src
 @test g[2].Q[1, 1] ≈ 1.0 atol=1e-6            #src
 @test length(g[3].basis.polynomials) == 1     #src
-@test g[3].basis.polynomials[1] ≈ (x[3] - x[1]) / √2 #src
+@test g[3].basis.polynomials[1] ≈ (x[2] - x[4]) / √2 #src
 @test size(g[3].Q) == (1, 1)                  #src
 @test g[3].Q[1, 1] ≈ 1.0 atol=1e-6            #src
 @test length(g[4].basis.polynomials) == 1     #src

--- a/docs/src/tutorials/Symmetry/permutation_symmetry.jl
+++ b/docs/src/tutorials/Symmetry/permutation_symmetry.jl
@@ -49,7 +49,6 @@ value(t)
 # We indeed find `-1`, let's verify that symmetry was exploited:
 
 g = gram_matrix(con_ref).sub_gram_matrices    #src
-display([g[i].basis.polynomials for i in eachindex(g)])
 @test length(g) == 4                          #src
 @test length(g[1].basis.polynomials) == 2     #src
 @test g[1].basis.polynomials[1] ≈ 0.5 * sum(x) #src

--- a/docs/src/tutorials/Symmetry/permutation_symmetry.jl
+++ b/docs/src/tutorials/Symmetry/permutation_symmetry.jl
@@ -48,22 +48,27 @@ value(t)
 
 # We indeed find `-1`, let's verify that symmetry was exploited:
 
-g = gram_matrix(con_ref).sub_gram_matrices #src
-@test length(g) == 4                       #src
-@test g[1].basis.polynomials == [sum(x), 1.0] #src
+g = gram_matrix(con_ref).sub_gram_matrices    #src
+@test length(g) == 4                          #src
+@test length(g[1].basis.polynomials) == 2     #src
+@test g[1].basis.polynomials[1] == 1.0        #src
+@test g[1].basis.polynomials[2] ≈ -0.5 * sum(x) #src
 @test size(g[1].Q) == (2, 2)                  #src
-@test g[1].Q[1, 1] ≈ 1/4 atol=1e-6            #src
-@test g[1].Q[1, 2] ≈ 1/2 atol=1e-6            #src
-@test g[1].Q[2, 2] ≈ 1.0 atol=1e-6            #src
-@test g[2].basis.polynomials == [x[1] - x[3]] #src
+@test g[1].Q[1, 1] ≈  1.0 atol=1e-6           #src
+@test g[1].Q[1, 2] ≈ -1.0 atol=1e-6           #src
+@test g[1].Q[2, 2] ≈  1.0 atol=1e-6           #src
+@test length(g[2].basis.polynomials) == 1     #src
+@test g[2].basis.polynomials[1] ≈ (x[2] - x[4]) / √2 #src
 @test size(g[2].Q) == (1, 1)                  #src
-@test g[2].Q[1, 1] ≈ 1/2 atol=1e-6            #src
-@test g[3].basis.polynomials == [x[2] - x[4]] #src
+@test g[2].Q[1, 1] ≈ 1.0 atol=1e-6            #src
+@test length(g[3].basis.polynomials) == 1     #src
+@test g[3].basis.polynomials[1] ≈ (x[3] - x[1]) / √2 #src
 @test size(g[3].Q) == (1, 1)                  #src
-@test g[3].Q[1, 1] ≈ 1/2 atol=1e-6            #src
-@test g[4].basis.polynomials == [x[1] - x[2] + x[3] - x[4]] #src
+@test g[3].Q[1, 1] ≈ 1.0 atol=1e-6            #src
+@test length(g[4].basis.polynomials) == 1     #src
+@test g[4].basis.polynomials[1] ≈ (-x[1] + x[2] - x[3] + x[4]) / 2 #src
 @test size(g[4].Q) == (1, 1)                  #src
-@test g[4].Q[1, 1] ≈ 1/4 atol=1e-6            #src
+@test g[4].Q[1, 1] ≈ 1.0 atol=1e-6            #src
 for g in gram_matrix(con_ref).sub_gram_matrices
     println(g.basis.polynomials)
 end

--- a/src/Certificate/Symmetry/wedderburn.jl
+++ b/src/Certificate/Symmetry/wedderburn.jl
@@ -103,7 +103,7 @@ function SumOfSquares.Certificate.get(cert::Ideal, attr::SumOfSquares.Certificat
         _RowEchelonMatrix()
     end
     return map(summands) do summand
-        R = SymbolicWedderburn.basis(summand)
+        R = SymbolicWedderburn.image_basis(summand)
         m = SymbolicWedderburn.multiplicity(summand)
         N = size(R, 1)
         d = SymbolicWedderburn.degree(summand)

--- a/src/Certificate/Symmetry/wedderburn.jl
+++ b/src/Certificate/Symmetry/wedderburn.jl
@@ -97,12 +97,17 @@ function SumOfSquares.Certificate.get(cert::Ideal, attr::SumOfSquares.Certificat
     # That block is the matrix `S` computed below.
     # So an invariant solution `b'*Q*b` satisfies `Diagonal(S' for S in ...) * Q * Diagonal(S for S in ...) = Q`.
     # Or in equivalently: `Q * Diagonal(S for S in ...) = Diagonal(inv(S') for S in ...) * Q`.
+    form = if T <: Union{AbstractFloat, Complex{<:AbstractFloat}}
+        _OrthogonalMatrix()
+        else
+        _RowEchelonMatrix()
+    end
     return map(summands) do summand
         R = SymbolicWedderburn.basis(summand)
         m = SymbolicWedderburn.multiplicity(summand)
         N = size(R, 1)
         d = SymbolicWedderburn.degree(summand)
-        S = matrix_reps(cert, R, basis, T, _OrthogonalMatrix())
+        S = matrix_reps(cert, R, basis, T, form)
         #S = matrix_reps(cert, R, basis, T, _RowEchelonMatrix())
         decomose_semisimple = d > 1
         if decomose_semisimple

--- a/src/Certificate/Symmetry/wedderburn.jl
+++ b/src/Certificate/Symmetry/wedderburn.jl
@@ -88,7 +88,7 @@ end
 function SumOfSquares.Certificate.get(cert::Ideal, attr::SumOfSquares.Certificate.GramBasis, poly)
     basis = SumOfSquares.Certificate.get(cert.certificate, attr, poly)
     T = SumOfSquares._complex(Float64, SumOfSquares.matrix_cone_type(typeof(cert)))
-    summands = SymbolicWedderburn.symmetry_adapted_basis(T, cert.pattern.group, basis, cert.pattern.action)
+    summands = SymbolicWedderburn.symmetry_adapted_basis(T, cert.pattern.group, cert.pattern.action, basis)
     # We have a new basis `b = vcat(R * basis.monomials for R in summands)``.
     # SymbolicWedderburn guarantees that the invariant subspace spanned by the
     # polynomials of the vector `R * basis.monomials` is invariant under the
@@ -99,16 +99,11 @@ function SumOfSquares.Certificate.get(cert::Ideal, attr::SumOfSquares.Certificat
     # Or in equivalently: `Q * Diagonal(S for S in ...) = Diagonal(inv(S') for S in ...) * Q`.
     return map(summands) do summand
         R = SymbolicWedderburn.basis(summand)
-        #@show typeof(R)
         m = SymbolicWedderburn.multiplicity(summand)
         N = size(R, 1)
         d = SymbolicWedderburn.degree(summand)
-        display(R)
-        @show R * basis.monomials
-        @show m
-        @show d
-        #display.(matrix_reps(cert, Matrix(T(1) * LinearAlgebra.I, 4, 4), basis, T, _RowEchelonMatrix()))
-        S = matrix_reps(cert, R, basis, T, _RowEchelonMatrix())
+        S = matrix_reps(cert, R, basis, T, _OrthogonalMatrix())
+        #S = matrix_reps(cert, R, basis, T, _RowEchelonMatrix())
         decomose_semisimple = d > 1
         if decomose_semisimple
             # If it's not orthogonal, how can we conclude that we can still use the semisimple summands block-decomposition ?
@@ -119,15 +114,11 @@ function SumOfSquares.Certificate.get(cert::Ideal, attr::SumOfSquares.Certificat
             # `X` and `inv(Y')` are not equivalent (to exclude the case 1. of Corollary 1.6.6) ?
             if !all(is_orthogonal, S)
                 R = orthogonalize(R)
-                display(R)
                 S = matrix_reps(cert, R, basis, T, _OrthogonalMatrix())
-                display.(S)
                 for i in 1:size(R, 1)
                     R[i, :] = LinearAlgebra.normalize(R[i, :])
                 end
-                display(R)
                 S = matrix_reps(cert, R, basis, T, _OrthogonalMatrix())
-                display.(S)
                 if !all(is_orthogonal, S)
                     error("The matrix representation induced from the action on the polynomial basis is not orthogonal.")
                     # We would like to just throw this warning and just not decompose the semisimple summand but

--- a/src/Certificate/Symmetry/wedderburn.jl
+++ b/src/Certificate/Symmetry/wedderburn.jl
@@ -109,7 +109,7 @@ function SumOfSquares.Certificate.get(cert::Ideal, attr::SumOfSquares.Certificat
         d = SymbolicWedderburn.degree(summand)
         S = matrix_reps(cert, R, basis, T, form)
         #S = matrix_reps(cert, R, basis, T, _RowEchelonMatrix())
-        decomose_semisimple = d > 1
+        decomose_semisimple = !SymbolicWedderburn.issimple(summand)
         if decomose_semisimple
             # If it's not orthogonal, how can we conclude that we can still use the semisimple summands block-decomposition ?
             # In Example 1.7.2 of Sagan's book, he uses Corollary 1.6.6 which requires that `X` and `Y` are irreducible

--- a/src/Certificate/Symmetry/wedderburn.jl
+++ b/src/Certificate/Symmetry/wedderburn.jl
@@ -88,7 +88,8 @@ end
 function SumOfSquares.Certificate.get(cert::Ideal, attr::SumOfSquares.Certificate.GramBasis, poly)
     basis = SumOfSquares.Certificate.get(cert.certificate, attr, poly)
     T = SumOfSquares._complex(Float64, SumOfSquares.matrix_cone_type(typeof(cert)))
-    summands = SymbolicWedderburn.symmetry_adapted_basis(T, cert.pattern.group, cert.pattern.action, basis)
+    # We set `semisimple=true` as we don't support simple yet since it would not give all the simple components but only one of them.
+    summands = SymbolicWedderburn.symmetry_adapted_basis(T, cert.pattern.group, cert.pattern.action, basis, semisimple=true)
     # We have a new basis `b = vcat(R * basis.monomials for R in summands)``.
     # SymbolicWedderburn guarantees that the invariant subspace spanned by the
     # polynomials of the vector `R * basis.monomials` is invariant under the
@@ -109,7 +110,7 @@ function SumOfSquares.Certificate.get(cert::Ideal, attr::SumOfSquares.Certificat
         d = SymbolicWedderburn.degree(summand)
         S = matrix_reps(cert, R, basis, T, form)
         #S = matrix_reps(cert, R, basis, T, _RowEchelonMatrix())
-        decomose_semisimple = !SymbolicWedderburn.issimple(summand)
+        decomose_semisimple = d > 1
         if decomose_semisimple
             # If it's not orthogonal, how can we conclude that we can still use the semisimple summands block-decomposition ?
             # In Example 1.7.2 of Sagan's book, he uses Corollary 1.6.6 which requires that `X` and `Y` are irreducible
@@ -134,7 +135,7 @@ function SumOfSquares.Certificate.get(cert::Ideal, attr::SumOfSquares.Certificat
             end
         end
         F = convert(Matrix{T}, R)
-        if decomose_semisimple
+        if d > 1
             if m > 1
                 U = ordered_block_diag(S, d)
             else


### PR DESCRIPTION
I made an update to https://github.com/kalmarek/SymbolicWedderburn.jl/pull/38. Here are the current failures even with the changes of this PR:
```jl
julia> include("src/tutorials/Symmetry/even_reduction.jl")
ERROR: LoadError: MethodError: no method matching svd!(::SparseArrays.SparseMatrixCSC{Float64, Int64})
Closest candidates are:
  svd!(::LinearAlgebra.AbstractTriangular; kwargs...) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/triangular.jl:2212
  svd!(::StridedMatrix{T}; full, alg) where T<:Union{Float32, Float64, ComplexF32, ComplexF64} at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/svd.jl:92
  svd!(::StridedMatrix{T}, ::StridedMatrix{T}) where T<:Union{Float32, Float64, ComplexF32, ComplexF64} at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/svd.jl:361
  ...
Stacktrace:
  [1] image_basis!(A::SparseArrays.SparseMatrixCSC{Float64, Int64})
    @ SymbolicWedderburn ~/.julia/dev/SymbolicWedderburn/src/eigenspacedecomposition.jl:96
  [2] image_basis(hom::SymbolicWedderburn.CachedExtensionHomomorphism{OnSign, Monomial{true}, Permutation{Int64, PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}}, SparseArrays.SparseMatrixCSC{Float64, Int64}, SymbolicWedderburn.ExtensionHomomorphism{OnSign, Monomial{true}, Int64, Vector{Monomial{true}}}}, χ::SymbolicWedderburn.Character{Float64, Int64, SymbolicWedderburn.CharacterTable{PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}, Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}, PermutationGroups.Orbit1{Permutation{Int64, PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}}, Nothing}}})
    @ SymbolicWedderburn ~/.julia/dev/SymbolicWedderburn/src/sa_basis.jl:9
  [3] (::SymbolicWedderburn.var"#103#105"{DataType, SymbolicWedderburn.CachedExtensionHomomorphism{OnSign, Monomial{true}, Permutation{Int64, PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}}, SparseArrays.SparseMatrixCSC{Float64, Int64}, SymbolicWedderburn.ExtensionHomomorphism{OnSign, Monomial{true}, Int64, Vector{Monomial{true}}}}})(::Tuple{SymbolicWedderburn.Character{Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}, Int64, SymbolicWedderburn.CharacterTable{PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}, Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}, PermutationGroups.Orbit1{Permutation{Int64, PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}}, Nothing}}}, Int64})
    @ SymbolicWedderburn ~/.julia/dev/SymbolicWedderburn/src/sa_basis.jl:216
  [4] iterate
    @ ./generator.jl:47 [inlined]
  [5] collect(itr::Base.Generator{Base.Iterators.Zip{Tuple{Vector{SymbolicWedderburn.Character{Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}, Int64, SymbolicWedderburn.CharacterTable{PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}, Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}, PermutationGroups.Orbit1{Permutation{Int64, PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}}, Nothing}}}}, Vector{Int64}}}, SymbolicWedderburn.var"#103#105"{DataType, SymbolicWedderburn.CachedExtensionHomomorphism{OnSign, Monomial{true}, Permutation{Int64, PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}}, SparseArrays.SparseMatrixCSC{Float64, Int64}, SymbolicWedderburn.ExtensionHomomorphism{OnSign, Monomial{true}, Int64, Vector{Monomial{true}}}}}})
    @ Base ./array.jl:678
  [6] map(f::Function, A::Base.Iterators.Zip{Tuple{Vector{SymbolicWedderburn.Character{Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}, Int64, SymbolicWedderburn.CharacterTable{PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}, Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}, PermutationGroups.Orbit1{Permutation{Int64, PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}}, Nothing}}}}, Vector{Int64}}})
    @ Base ./abstractarray.jl:2323
  [7] symmetry_adapted_basis(T::Type, tbl::SymbolicWedderburn.CharacterTable{PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}, Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}, PermutationGroups.Orbit1{Permutation{Int64, PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}}, Nothing}}, action::OnSign, basis::MonomialBasis{Monomial{true}, MonomialVector{true}}; semisimple::Bool)
    @ SymbolicWedderburn ~/.julia/dev/SymbolicWedderburn/src/sa_basis.jl:213
  [8] #symmetry_adapted_basis#101
    @ ~/.julia/dev/SymbolicWedderburn/src/sa_basis.jl:194 [inlined]
  [9] symmetry_adapted_basis (repeats 2 times)
    @ ~/.julia/dev/SymbolicWedderburn/src/sa_basis.jl:193 [inlined]
 [10] get(cert::SumOfSquares.Certificate.Symmetry.Ideal{SumOfSquares.Certificate.Newton{SOSCone, MonomialBasis, Tuple{}}, PermGroup{Int64, StabilizerChain{Int64, Perm{Int64}, Schreier{Perm{Int64}, Int64, Int64, PermutationGroups.Orbit1{Int64, Int64}, typeof(^)}}}, OnSign}, attr::SumOfSquares.Certificate.GramBasis, poly::Polynomial{true, MathOptInterface.ScalarAffineFunction{Float64}})
    @ SumOfSquares.Certificate.Symmetry ~/.julia/dev/SumOfSquares/src/Certificate/Symmetry/wedderburn.jl:91

julia> include("src/tutorials/Symmetry/dihedral_symmetry_of_the_robinson_form.jl")
SymbolicWedderburn.action(DihedralAction(), g, poly) = x⁶ - x⁴y² - x²y⁴ + y⁶ - x⁴ + 3x²y² - y⁴ - x² - y² + 1
SymbolicWedderburn.action(DihedralAction(), g, poly) = x⁶ - x⁴y² - x²y⁴ + y⁶ - x⁴ + 3x²y² - y⁴ - x² - y² + 1
SymbolicWedderburn.action(DihedralAction(), g, poly) = x⁶ - x⁴y² - x²y⁴ + y⁶ - x⁴ + 3x²y² - y⁴ - x² - y² + 1
SymbolicWedderburn.action(DihedralAction(), g, poly) = x⁶ - x⁴y² - x²y⁴ + y⁶ - x⁴ + 3x²y² - y⁴ - x² - y² + 1
SymbolicWedderburn.action(DihedralAction(), g, poly) = x⁶ - x⁴y² - x²y⁴ + y⁶ - x⁴ + 3x²y² - y⁴ - x² - y² + 1
SymbolicWedderburn.action(DihedralAction(), g, poly) = x⁶ - x⁴y² - x²y⁴ + y⁶ - x⁴ + 3x²y² - y⁴ - x² - y² + 1
SymbolicWedderburn.action(DihedralAction(), g, poly) = x⁶ - x⁴y² - x²y⁴ + y⁶ - x⁴ + 3x²y² - y⁴ - x² - y² + 1
SymbolicWedderburn.action(DihedralAction(), g, poly) = x⁶ - x⁴y² - x²y⁴ + y⁶ - x⁴ + 3x²y² - y⁴ - x² - y² + 1
ERROR: LoadError: MethodError: no method matching matrix_projection(::SymbolicWedderburn.CachedExtensionHomomorphism{DihedralAction, Monomial{true}, DihedralElement, SparseArrays.SparseMatrixCSC{Float64, Int64}, SymbolicWedderburn.ExtensionHomomorphism{DihedralAction, Monomial{true}, Int64, Vector{Monomial{true}}}}, ::StarAlgebras.AlgebraElement{StarAlgebras.StarAlgebra{DihedralGroup, DihedralElement, StarAlgebras.CachedMTable{DihedralElement, UInt16, StarAlgebras.Basis{DihedralElement, UInt16, Vector{DihedralElement}}, Matrix{UInt16}, false}, StarAlgebras.Basis{DihedralElement, UInt16, Vector{DihedralElement}}}, Float64, Vector{Float64}})
Closest candidates are:
  matrix_projection(::SymbolicWedderburn.InducedActionHomomorphism{var"#s126", T} where {var"#s126"<:SymbolicWedderburn.ByPermutations, T}, ::StarAlgebras.AlgebraElement) at /home/blegat/.julia/dev/SymbolicWedderburn/src/projections.jl:94
  matrix_projection(::SymbolicWedderburn.InducedActionHomomorphism{var"#s125", T} where {var"#s125"<:SymbolicWedderburn.ByPermutations, T}, ::StarAlgebras.AlgebraElement, ::Any) at /home/blegat/.julia/dev/SymbolicWedderburn/src/projections.jl:94
  matrix_projection(::StarAlgebras.AlgebraElement{var"#s124", T, V} where {var"#s124"<:(StarAlgebras.StarAlgebra{var"#s123", T, M, B} where {var"#s123"<:AbstractAlgebra.AbstractPermutationGroup, T, M<:StarAlgebras.MultiplicativeStructure, B<:(StarAlgebras.AbstractBasis{T, I} where I)}), T, V<:AbstractVector{T}}, ::Any) at /home/blegat/.julia/dev/SymbolicWedderburn/src/projections.jl:112
Stacktrace:
  [1] image_basis(hom::SymbolicWedderburn.CachedExtensionHomomorphism{DihedralAction, Monomial{true}, DihedralElement, SparseArrays.SparseMatrixCSC{Float64, Int64}, SymbolicWedderburn.ExtensionHomomorphism{DihedralAction, Monomial{true}, Int64, Vector{Monomial{true}}}}, α::StarAlgebras.AlgebraElement{StarAlgebras.StarAlgebra{DihedralGroup, DihedralElement, StarAlgebras.CachedMTable{DihedralElement, UInt16, StarAlgebras.Basis{DihedralElement, UInt16, Vector{DihedralElement}}, Matrix{UInt16}, false}, StarAlgebras.Basis{DihedralElement, UInt16, Vector{DihedralElement}}}, Float64, Vector{Float64}})
    @ SymbolicWedderburn ~/.julia/dev/SymbolicWedderburn/src/sa_basis.jl:19
  [2] (::SymbolicWedderburn.var"#104#106"{DataType, SymbolicWedderburn.CachedExtensionHomomorphism{DihedralAction, Monomial{true}, DihedralElement, SparseArrays.SparseMatrixCSC{Float64, Int64}, SymbolicWedderburn.ExtensionHomomorphism{DihedralAction, Monomial{true}, Int64, Vector{Monomial{true}}}}})(::Tuple{StarAlgebras.AlgebraElement{StarAlgebras.StarAlgebra{DihedralGroup, DihedralElement, StarAlgebras.CachedMTable{DihedralElement, UInt16, StarAlgebras.Basis{DihedralElement, UInt16, Vector{DihedralElement}}, Matrix{UInt16}, false}, StarAlgebras.Basis{DihedralElement, UInt16, Vector{DihedralElement}}}, Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}, Vector{Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}}}, Int64, Int64, Bool})
    @ SymbolicWedderburn ~/.julia/dev/SymbolicWedderburn/src/sa_basis.jl:229
  [3] iterate
    @ ./generator.jl:47 [inlined]
  [4] collect(itr::Base.Generator{Base.Iterators.Zip{Tuple{Vector{StarAlgebras.AlgebraElement{StarAlgebras.StarAlgebra{DihedralGroup, DihedralElement, StarAlgebras.CachedMTable{DihedralElement, UInt16, StarAlgebras.Basis{DihedralElement, UInt16, Vector{DihedralElement}}, Matrix{UInt16}, false}, StarAlgebras.Basis{DihedralElement, UInt16, Vector{DihedralElement}}}, Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}, Vector{Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}}}}, Vector{Int64}, Vector{Int64}, BitVector}}, SymbolicWedderburn.var"#104#106"{DataType, SymbolicWedderburn.CachedExtensionHomomorphism{DihedralAction, Monomial{true}, DihedralElement, SparseArrays.SparseMatrixCSC{Float64, Int64}, SymbolicWedderburn.ExtensionHomomorphism{DihedralAction, Monomial{true}, Int64, Vector{Monomial{true}}}}}})
    @ Base ./array.jl:678
  [5] map(f::Function, A::Base.Iterators.Zip{Tuple{Vector{StarAlgebras.AlgebraElement{StarAlgebras.StarAlgebra{DihedralGroup, DihedralElement, StarAlgebras.CachedMTable{DihedralElement, UInt16, StarAlgebras.Basis{DihedralElement, UInt16, Vector{DihedralElement}}, Matrix{UInt16}, false}, StarAlgebras.Basis{DihedralElement, UInt16, Vector{DihedralElement}}}, Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}, Vector{Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}}}}, Vector{Int64}, Vector{Int64}, BitVector}})
    @ Base ./abstractarray.jl:2323
  [6] symmetry_adapted_basis(T::Type, tbl::SymbolicWedderburn.CharacterTable{DihedralGroup, Cyclotomics.Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}, PermutationGroups.Orbit1{DihedralElement, Nothing}}, action::DihedralAction, basis::MonomialBasis{Monomial{true}, MonomialVector{true}}; semisimple::Bool)
    @ SymbolicWedderburn ~/.julia/dev/SymbolicWedderburn/src/sa_basis.jl:227
  [7] #symmetry_adapted_basis#101
    @ ~/.julia/dev/SymbolicWedderburn/src/sa_basis.jl:194 [inlined]
  [8] symmetry_adapted_basis (repeats 2 times)
    @ ~/.julia/dev/SymbolicWedderburn/src/sa_basis.jl:193 [inlined]
  [9] get(cert::SumOfSquares.Certificate.Symmetry.Ideal{SumOfSquares.Certificate.Newton{SOSCone, MonomialBasis, Tuple{}}, DihedralGroup, DihedralAction}, attr::SumOfSquares.Certificate.GramBasis, poly::Polynomial{true, MathOptInterface.ScalarAffineFunction{Float64}})
    @ SumOfSquares.Certificate.Symmetry ~/.julia/dev/SumOfSquares/src/Certificate/Symmetry/wedderburn.jl:91
```