### PR TITLE
Remove !src in tutorials

### DIFF
--- a/docs/src/tutorials/Getting started/sum-of-squares_matrices.jl
+++ b/docs/src/tutorials/Getting started/sum-of-squares_matrices.jl
@@ -39,7 +39,7 @@ model = SOSModel(solver)
 mat_cref = @constraint(model, P in PSDCone())
 optimize!(model)
 @test termination_status(model) == MOI.OPTIMAL #src
-termination_status(model) #!src
+termination_status(model)
 
 # While the reformulation of sos matrix to sos polynomial is rather simple, as explained in the "Sum-of-Squares reformulation" section below, there is a technical subtelty about the Newton polytope that if not handled correctly may result in an SDP of large size with bad numerical behavior. For this reason, it is recommended to model sos *matrix* constraints as such as will be shown in this notebook and not do the formulation manually unless there is a specific reason to do so.
 #

--- a/docs/src/tutorials/Noncommutative and Hermitian/noncommutative_variables.jl
+++ b/docs/src/tutorials/Noncommutative and Hermitian/noncommutative_variables.jl
@@ -39,14 +39,14 @@ gram_matrix(con_ref).Q
 # When asking for the SOS decomposition, the numerically small entries makes the solution less readable.
 
 @test length(sos_decomposition(con_ref).ps) == 2 #src
-sos_decomposition(con_ref) #!src
+sos_decomposition(con_ref)
 
 # They are however easily discarded by using a nonzero tolerance:
 
 dec = sos_decomposition(con_ref, 1e-6)                    #src
 @test length(dec.ps) == 1                                 #src
 @test sign(first(coefficients(dec.ps[1]))) * dec.ps[1] ≈ x * y + x^2 rtol=1e-5 atol=1e-5 #src
-sos_decomposition(con_ref, 1e-6)       #!src
+sos_decomposition(con_ref, 1e-6)
 
 # ## Example 2.2
 #

--- a/docs/src/tutorials/Noncommutative and Hermitian/sums_of_hermitian_squares.jl
+++ b/docs/src/tutorials/Noncommutative and Hermitian/sums_of_hermitian_squares.jl
@@ -27,4 +27,4 @@ optimize!(model)
 dec = sos_decomposition(c, 1e-6) #src
 @test length(dec.ps) == 1 #src
 @test sign(real(first(coefficients(dec.ps[1])))) * dec.ps[1] ≈ x - im * y atol=1e-6 rtol=1e-6 #src
-sos_decomposition(c, 1e-6) #!src
+sos_decomposition(c, 1e-6)


### PR DESCRIPTION
I don't know where it came from. It's not defined in Literate. Maybe it came from a Search+Replace from `!jl`