### PR TITLE
More robust infeasibility check for quadrotor

### DIFF
--- a/docs/src/tutorials/Systems and Control/quadrotor.jl
+++ b/docs/src/tutorials/Systems and Control/quadrotor.jl
@@ -157,12 +157,12 @@ function γ_step(solver, V, γ_min, degree_k, degree_s3; γ_tol = 1e-1, max_iter
         @info("Iteration $num_iters/$max_iters : Solving with $(solver_name(model)) for `γ = $γ`")
         optimize!(model)
         @info("After $(solve_time(model)) seconds, terminated with $(termination_status(model)) ($(raw_status(model)))")
-        if primal_status(model) == MOI.FEASIBLE_POINT || primal_status(model) == MOI.NEARLY_FEASIBLE_POINT
+        if primal_status(model) in [MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT]
             @info("Feasible solution found : primal is $(primal_status(model))")
             γ_min = γ
             k_best = value.(k)
             s3_best = value(s3)
-        elseif dual_status(model) == MOI.INFEASIBILITY_CERTIFICATE
+        elseif dual_status(model) == MOI.INFEASIBILITY_CERTIFICATE || termination_status(model) in [MOI.INFEASIBLE, MOI.INFEASIBLE_OR_UNBOUNDED] # `INFEASIBLE_OR_UNBOUNDED` means `INFEASIBLE` because there is no objective so it cannot be unbounded
             @info("Infeasibility certificate found : dual is $(dual_status(model))")
             if γ == γ0_min # This corresponds to the case above where we reached the tol or max iteration and we just did a last run at the value of `γ_min` provided by the user
                 error("The value `$γ0_min` of `γ_min` provided is not feasible")


### PR DESCRIPTION
Currently failing in CI with
```julia
[ Info: Iteration 1/10 : Solving with CSDP for `γ = 1.0`
[ Info: After 1.9801158905029297 seconds, terminated with INFEASIBLE (Problem is primal infeasible.)
┌ Warning: Giving up Problem is primal infeasible., INFEASIBLE, INFEASIBLE_POINT, UNKNOWN_RESULT_STATUS
└ @ Main.var"##29227" ~/work/SumOfSquares.jl/SumOfSquares.jl/docs/src/tutorials/Systems and Control/quadrotor.jl:172
┌ Warning: Cannot find any infeasible `γ` after 1 iterations
└ @ Main.var"##29227" ~/work/SumOfSquares.jl/SumOfSquares.jl/docs/src/tutorials/Systems and Control/quadrotor.jl:180
Systems and Control: Test Failed at /home/runner/work/SumOfSquares.jl/SumOfSquares.jl/docs/src/tutorials/Systems and Control/quadrotor.jl:188
```
because the dual status is `UNKNOWN_RESULT_STATUS`

Actually, this is not needed as it will be fixed by https://github.com/jump-dev/CSDP.jl/pull/89