### PR TITLE
Get maxtrix_cone_type without constructing the cone

### DIFF
--- a/src/Bridges/Constraint/utilities.jl
+++ b/src/Bridges/Constraint/utilities.jl
@@ -7,17 +7,17 @@ function union_constraint_types(MCT)
 end
 function union_set_types(MCT)
     return Union{
-        typeof(SOS.matrix_cone(MCT, 0)),
-        typeof(SOS.matrix_cone(MCT, 1)),
-        typeof(SOS.matrix_cone(MCT, 2)),
-        typeof(SOS.matrix_cone(MCT, 3)),
+        SOS.matrix_cone_type(MCT, 0),
+        SOS.matrix_cone_type(MCT, 1),
+        SOS.matrix_cone_type(MCT, 2),
+        SOS.matrix_cone_type(MCT, 3),
     }
 end
 function constrained_variable_types(MCT)
     return [
-        (typeof(SOS.matrix_cone(MCT, 0)),),
-        (typeof(SOS.matrix_cone(MCT, 1)),),
-        (typeof(SOS.matrix_cone(MCT, 2)),),
-        (typeof(SOS.matrix_cone(MCT, 3)),),
+        (SOS.matrix_cone_type(MCT, 0),),
+        (SOS.matrix_cone_type(MCT, 1),),
+        (SOS.matrix_cone_type(MCT, 2),),
+        (SOS.matrix_cone_type(MCT, 3),),
     ]
 end

--- a/src/diagonally_dominant.jl
+++ b/src/diagonally_dominant.jl
@@ -24,6 +24,21 @@ function matrix_cone(
     end
 end
 
+function matrix_cone_type(
+    S::Type{<:MOI.AbstractSymmetricMatrixSetTriangle},
+    side_dimension,
+)
+    if iszero(side_dimension)
+        return EmptyCone
+    elseif isone(side_dimension)
+        return MOI.Nonnegatives
+    elseif side_dimension == 2
+        return PositiveSemidefinite2x2ConeTriangle
+    else
+        return S
+    end
+end
+
 """
     struct DiagonallyDominantConeTriangle <: MOI.AbstractSymmetricMatrixSetTriangle
         side_dimension::Int
@@ -47,6 +62,16 @@ function matrix_cone(S::Type{DiagonallyDominantConeTriangle}, side_dimension)
     else
         # With `side_dimension` = 2, we want to avoid using SOC and only use LP
         return S(side_dimension)
+    end
+end
+
+function matrix_cone_type(S::Type{DiagonallyDominantConeTriangle}, side_dimension)
+    if iszero(side_dimension)
+        return EmptyCone
+    elseif isone(side_dimension)
+        return MOI.Nonnegatives
+    else
+        return S
     end
 end
 
@@ -78,6 +103,21 @@ function matrix_cone(
         return PositiveSemidefinite2x2ConeTriangle()
     else
         return S(side_dimension)
+    end
+end
+
+function matrix_cone_type(
+    S::Type{ScaledDiagonallyDominantConeTriangle},
+    side_dimension,
+)
+    if iszero(side_dimension)
+        return EmptyCone
+    elseif isone(side_dimension)
+        return MOI.Nonnegatives
+    elseif side_dimension == 2
+        return PositiveSemidefinite2x2ConeTriangle
+    else
+        return S
     end
 end
 

--- a/src/diagonally_dominant.jl
+++ b/src/diagonally_dominant.jl
@@ -65,7 +65,10 @@ function matrix_cone(S::Type{DiagonallyDominantConeTriangle}, side_dimension)
     end
 end
 
-function matrix_cone_type(S::Type{DiagonallyDominantConeTriangle}, side_dimension)
+function matrix_cone_type(
+    S::Type{DiagonallyDominantConeTriangle},
+    side_dimension,
+)
     if iszero(side_dimension)
         return EmptyCone
     elseif isone(side_dimension)

--- a/src/sos_polynomial.jl
+++ b/src/sos_polynomial.jl
@@ -110,10 +110,10 @@ end
 
 function union_constraint_indices_types(MCT)
     return Union{
-        MOI.ConstraintIndex{MOI.VectorOfVariables,typeof(matrix_cone(MCT, 0))},
-        MOI.ConstraintIndex{MOI.VectorOfVariables,typeof(matrix_cone(MCT, 1))},
-        MOI.ConstraintIndex{MOI.VectorOfVariables,typeof(matrix_cone(MCT, 2))},
-        MOI.ConstraintIndex{MOI.VectorOfVariables,typeof(matrix_cone(MCT, 3))},
+        MOI.ConstraintIndex{MOI.VectorOfVariables,matrix_cone_type(MCT, 0)},
+        MOI.ConstraintIndex{MOI.VectorOfVariables,matrix_cone_type(MCT, 1)},
+        MOI.ConstraintIndex{MOI.VectorOfVariables,matrix_cone_type(MCT, 2)},
+        MOI.ConstraintIndex{MOI.VectorOfVariables,matrix_cone_type(MCT, 3)},
     }
 end
 

--- a/src/sos_polynomial.jl
+++ b/src/sos_polynomial.jl
@@ -4,6 +4,13 @@ function matrix_cone(::Type{COI.HermitianPositiveSemidefiniteConeTriangle}, d)
     return COI.HermitianPositiveSemidefiniteConeTriangle(d)
 end
 
+function matrix_cone_type(
+    ::Type{COI.HermitianPositiveSemidefiniteConeTriangle},
+    d,
+)
+    return COI.HermitianPositiveSemidefiniteConeTriangle
+end
+
 function vectorized_matrix(Q, basis, ::Type, ::Type)
     return MultivariateMoments.SymMatrix(Q, basis)
 end


### PR DESCRIPTION
By having a separate function to compute the type of the underlying cone for each matrix type, given the side dimension, constructing the cone and taking the typeof can be avoided. This has the benefit of enabling sparse cones for DSOS and SDSOS.