### PR TITLE
Add alternative syntax for SOSCone

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ SymbolicWedderburn = "858aa9a9-4c7c-4c62-b466-2421203962a2"
 
 [compat]
 DataStructures = "0.18"
-JuMP = "1.5"
+JuMP = "1.10"
 MathOptInterface = "1.13"
 MultivariateBases = "0.2"
 MultivariateMoments = "0.4"

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -324,6 +324,16 @@ function PolyJuMP.bridges(
     return [Bridges.Constraint.SOSPolynomialInSemialgebraicSetBridge]
 end
 
+# Syntax: `@constraint(model, a >= b, SOSCone())`
+function JuMP.build_constraint(
+    _error::Function,
+    f,
+    ::JuMP.Nonnegatives,
+    extra::SOSLikeCone,
+)
+    return build_constraint(_error, f, extra)
+end
+
 function JuMP.build_constraint(_error::Function, p, cone::SOSLikeCone; kws...)
     coefs = PolyJuMP.non_constant_coefficients(p)
     monos = MP.monomials(p)

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -329,9 +329,10 @@ function JuMP.build_constraint(
     _error::Function,
     f,
     ::JuMP.Nonnegatives,
-    extra::SOSLikeCone,
+    extra::SOSLikeCone;
+    kws...,
 )
-    return build_constraint(_error, f, extra)
+    return build_constraint(_error, f, extra; kws...)
 end
 
 function JuMP.build_constraint(_error::Function, p, cone::SOSLikeCone; kws...)

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -32,6 +32,7 @@ end
     @test sprint(show, MIME"text/latex"(), dref) ==
           "\$\$ (a)x^{2} \\text{ is DSOS} \$\$"
     model = Model()
+    @variable(model, a)
     for sparsity in [Sparsity.NoPattern(), Sparsity.Variable()]
         cref_fix = @constraint(
             model,

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -31,10 +31,12 @@ end
     @test sprint(show, MIME"text/plain"(), dref) == "(a)x² is DSOS"
     @test sprint(show, MIME"text/latex"(), dref) ==
           "\$\$ (a)x^{2} \\text{ is DSOS} \$\$"
+    model = Model()
     for sparsity in [Sparsity.NoPattern(), Sparsity.Variable()]
         cref_fix = @constraint(
             model,
             a * x^2 >= 1,
+            SOSCone(),
             domain = (@set x == 1),
             sparsity = sparsity
         )

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -48,6 +48,7 @@ end
         cref_fix = @constraint(
             model,
             a * x^2 >= 1,
+            SOSCone(),
             domain = (@set x >= 1),
             sparsity = sparsity
         )


### PR DESCRIPTION
Should be consistent with the behavior of other conic sets with the new feature added in https://github.com/jump-dev/JuMP.jl/pull/3273