### PR TITLE
Fix errors with missing docstrings from PolyJuMP

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -59,7 +59,7 @@ makedocs(
     ],
     # The following ensures that we only include the docstrings from
     # this module for functions define in Base that we overwrite.
-    modules = [SumOfSquares, PolyJuMP],
+    modules = [SumOfSquares],
     plugins = [
         DocumenterCitations.CitationBibliography(
             joinpath(@__DIR__, "src", "references.bib");


### PR DESCRIPTION
Having the doc build of SumOfSquares failing everytime we add a docstring in PolyJuMP is a bit annoying